### PR TITLE
chore: update action-format

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -12,7 +12,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: suzuki-shunsuke/github-action-format@v0.1.1
+    - uses: suzuki-shunsuke/github-action-format@main
       with:
         github_token: ${{ inputs.github_token }}
         working_directory: ${{ inputs.working_directory }}

--- a/action.yaml
+++ b/action.yaml
@@ -16,7 +16,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: suzuki-shunsuke/github-action-format@main
+    - uses: suzuki-shunsuke/github-action-format@7afa92031ddd24c88bd8f6dd2b1c3649c9f5612a # v0.2.0
       with:
         github_token: ${{ inputs.github_token }}
         working_directory: ${{ inputs.working_directory }}

--- a/action.yaml
+++ b/action.yaml
@@ -9,6 +9,10 @@ inputs:
     description: working directory
     required: false
     default: ""
+  skip_push:
+    required: false
+    description: If "true", this action skips pushing a commit
+    default: false
 runs:
   using: composite
   steps:
@@ -18,3 +22,4 @@ runs:
         working_directory: ${{ inputs.working_directory }}
         command: terraform fmt -recursive | sed "s|^|${{ inputs.working_directory }}/|"
         commit_message: "style: terraform fmt -recursive"
+        skip_push: ${{ inputs.skip_push }}


### PR DESCRIPTION
## ⚠️ Breaking Changes

The default behaviour is changed. The action pushes a commit even if the event isn't pull_request.

To change the behaviour, please use the input `skip_push`.

## Features

Add a field `skip_push`

By default this action pushes a commit to format code if code isn't formatted.
You can skip pushing a commit using the input `skip_push`.

e.g.

```yaml
- uses: suzuki-shunsuke/github-action-terraform-fmt@v0.2.0
  with:
    skip_push: ${{ github.event_name != 'pull_request' && ! startsWith(github.event_name, 'pull_request_') }}
```